### PR TITLE
docs: change docs link to new domain

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -10,7 +10,7 @@ image::https://forthebadge.com/images/badges/gluten-free.svg[Gluten Free]
 == Documentation
 The full Documentation of all modules is located here:
 
-https://melodious-florentine-5ff546.netlify.app[Documentation]
+https://nix-prefab.org[Documentation]
 
 [what-is]
 == What is nix-basement?


### PR DESCRIPTION
I configured the netlify-deployment to use the custom domain. Now the link in the README should be changed.